### PR TITLE
updated date parsing logic to handle alternative date formats (incl timezone)

### DIFF
--- a/lib/simplify.js
+++ b/lib/simplify.js
@@ -40,22 +40,35 @@ module.exports = {
 		});
 	},
 	castDateValues: function(getTagValue, setTagValue) {
+		var dateTimePattern = /^(\d{4})[-:](\d{2})[-:](\d{2})[\sT]{1}(\d{2}):(\d{2}):(\d{2})(([-+]\d{1,2}):(\d{2}))?$/i;
 		dateTags.forEach(function(t) {
 			var dateStrVal = getTagValue(t);
 			if(dateStrVal) {
-				var parts = dateStrVal.split(' '),
-					dateParts = parts[0].split(':'),
-					timeParts = parts[1].split(':');
-				var date = new Date();
-				date.setUTCFullYear(dateParts[0]);
-				date.setUTCMonth(dateParts[1] - 1);
-				date.setUTCDate(dateParts[2]);
-				date.setUTCHours(timeParts[0]);
-				date.setUTCMinutes(timeParts[1]);
-				date.setUTCSeconds(timeParts[2]);
-				date.setUTCMilliseconds(0);
-				var timestamp = date.getTime() / 1000;
-				setTagValue(t, timestamp);
+				var parts = dateTimePattern.exec(dateStrVal);
+				if (parts) {
+					// discard the full match
+					parts.shift();
+					// parse zero-padded number strings in base 10
+					parts = parts.map(function(i) {
+						var val = parseInt(i, 10);
+						return isNaN(val) ? i : val;
+					});
+					// zero-index the month
+					parts[1] -= 1;
+					// adjust for timezone if found
+					if (parts[7] || parts[8]) {
+						if (parts[7] < 0) {
+							parts[8] *= -1;
+						}
+						parts[3] -= parts[7];
+						parts[4] -= parts[8];
+					}
+					// create the date object
+					var date = new Date(Date.UTC.apply(this, parts.slice(0,6)));
+					date.setUTCMilliseconds(0);
+					var timestamp = date.getTime() / 1000;
+					setTagValue(t, timestamp);
+				}
 			}
 		});
 	},


### PR DESCRIPTION
I'm using your library in my project (https://www.npmjs.com/package/exif-renamer) and I noticed that some date formats are not parsed correctly. For example, I have a JPG with a DateTimeOriginal in the format: ```2004-09-04T23:39:06-08:00```.

This updated parsing logic uses regex to find the parts, parses them using base 10 to avoid zero-padded number strings being treated as octals, and does timezone adjustment if a timezone is found. It still supports dates in the format ```YYYY:MM:DD hh:mm:ss```.

Thanks for the great module!