### PR TITLE
Improve date parsing to handle ISO 8601 dates with timezone offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.8 - April 9th 2015
+
+- parse ISO 8601 dates with timezone offset

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,0 +1,73 @@
+function parseNumber(s) {
+	return parseInt(s, 10);
+}
+
+//in seconds
+var hours = 3600;
+var minutes = 60;
+
+//take date (year, month, day) and time (hour, minutes, seconds) digits in UTC
+//and return a timestamp in seconds
+function parseDateTimeParts(dateParts, timeParts) {
+	var date = new Date();
+	date.setUTCFullYear(dateParts[0]);
+	date.setUTCMonth(dateParts[1] - 1);
+	date.setUTCDate(dateParts[2]);
+	date.setUTCHours(timeParts[0]);
+	date.setUTCMinutes(timeParts[1]);
+	date.setUTCSeconds(timeParts[2]);
+	date.setUTCMilliseconds(0);
+	var timestamp = date.getTime() / 1000;
+	return timestamp;
+}
+
+//parse date with "2004-09-04T23:39:06-08:00" format, convert to utc timestamp in seconds
+function parseDateWithTimezoneFormat(dateTimeStr) {
+
+	var dateParts = dateTimeStr.substr(0, 10).split('-');
+	var timeParts = dateTimeStr.substr(11, 8).split(':');
+	var timezoneStr = dateTimeStr.substr(19, 6);
+	var timezoneParts = timezoneStr.split(':').map(parseNumber);
+	var timezoneOffset = (timezoneParts[0] * hours) + 
+		(timezoneParts[1] * minutes);
+
+	var timestamp = parseDateTimeParts(dateParts, timeParts);
+	return timestamp + timezoneOffset;
+}
+
+//parse date with "YYYY:MM:DD hh:mm:ss" format, convert to utc timestamp in seconds
+function parseDateWithSpecFormat(dateTimeStr) {
+	var parts = dateTimeStr.split(' '),
+		dateParts = parts[0].split(':'),
+		timeParts = parts[1].split(':');
+	
+	return parseDateTimeParts(dateParts, timeParts);
+
+	return timestamp;
+}
+
+function parseExifDate(dateTimeStr) {
+	//some easy checks to determine two common date formats
+
+	//is the date in the standard "YYYY:MM:DD hh:mm:ss" format?
+	var isSpecFormat = dateTimeStr.length === 19 &&
+		dateTimeStr.charAt(4) === ':';
+	//is the date in the non-standard format,
+	//"2004-09-04T23:39:06-08:00" to include a timezone?
+	var isTimezoneFormat = dateTimeStr.length === 25 &&
+		dateTimeStr.charAt(10) === 'T';
+	var timestamp;
+
+	if(isTimezoneFormat) {
+		return date.parseDateWithTimezoneFormat(dateTimeStr);
+	}
+	else if(isSpecFormat) {
+		return date.parseDateWithSpecFormat(dateTimeStr);
+	}
+}
+
+module.exports = {
+	parseDateWithSpecFormat: parseDateWithSpecFormat,
+	parseDateWithTimezoneFormat: parseDateWithTimezoneFormat,
+	parseExifDate: parseExifDate
+};

--- a/lib/date.js
+++ b/lib/date.js
@@ -9,6 +9,8 @@ var minutes = 60;
 //take date (year, month, day) and time (hour, minutes, seconds) digits in UTC
 //and return a timestamp in seconds
 function parseDateTimeParts(dateParts, timeParts) {
+	dateParts = dateParts.map(parseNumber);
+	timeParts = timeParts.map(parseNumber);
 	var date = new Date();
 	date.setUTCFullYear(dateParts[0]);
 	date.setUTCMonth(dateParts[1] - 1);
@@ -21,7 +23,9 @@ function parseDateTimeParts(dateParts, timeParts) {
 	return timestamp;
 }
 
-//parse date with "2004-09-04T23:39:06-08:00" format, convert to utc timestamp in seconds
+//parse date with "2004-09-04T23:39:06-08:00" format,
+//one of the formats supported by ISO 8601, and
+//convert to utc timestamp in seconds
 function parseDateWithTimezoneFormat(dateTimeStr) {
 
 	var dateParts = dateTimeStr.substr(0, 10).split('-');
@@ -32,7 +36,13 @@ function parseDateWithTimezoneFormat(dateTimeStr) {
 		(timezoneParts[1] * minutes);
 
 	var timestamp = parseDateTimeParts(dateParts, timeParts);
-	return timestamp + timezoneOffset;
+	//minus because the timezoneOffset describes
+	//how much the described time is ahead of UTC
+	timestamp -= timezoneOffset;
+
+	if(typeof timestamp === 'number' && !isNaN(timestamp)) {
+		return timestamp;
+	}
 }
 
 //parse date with "YYYY:MM:DD hh:mm:ss" format, convert to utc timestamp in seconds
@@ -41,9 +51,11 @@ function parseDateWithSpecFormat(dateTimeStr) {
 		dateParts = parts[0].split(':'),
 		timeParts = parts[1].split(':');
 	
-	return parseDateTimeParts(dateParts, timeParts);
+	var timestamp = parseDateTimeParts(dateParts, timeParts);
 
-	return timestamp;
+	if(typeof timestamp === 'number' && !isNaN(timestamp)) {
+		return timestamp;
+	}
 }
 
 function parseExifDate(dateTimeStr) {

--- a/lib/date.js
+++ b/lib/date.js
@@ -71,10 +71,10 @@ function parseExifDate(dateTimeStr) {
 	var timestamp;
 
 	if(isTimezoneFormat) {
-		return date.parseDateWithTimezoneFormat(dateTimeStr);
+		return parseDateWithTimezoneFormat(dateTimeStr);
 	}
 	else if(isSpecFormat) {
-		return date.parseDateWithSpecFormat(dateTimeStr);
+		return parseDateWithSpecFormat(dateTimeStr);
 	}
 }
 

--- a/lib/simplify.js
+++ b/lib/simplify.js
@@ -1,4 +1,5 @@
 var exif = require('./exif');
+var date = require('./date');
 
 var degreeTags = [{
 	section: exif.GPSIFD,
@@ -43,19 +44,11 @@ module.exports = {
 		dateTags.forEach(function(t) {
 			var dateStrVal = getTagValue(t);
 			if(dateStrVal) {
-				var parts = dateStrVal.split(' '),
-					dateParts = parts[0].split(':'),
-					timeParts = parts[1].split(':');
-				var date = new Date();
-				date.setUTCFullYear(dateParts[0]);
-				date.setUTCMonth(dateParts[1] - 1);
-				date.setUTCDate(dateParts[2]);
-				date.setUTCHours(timeParts[0]);
-				date.setUTCMinutes(timeParts[1]);
-				date.setUTCSeconds(timeParts[2]);
-				date.setUTCMilliseconds(0);
-				var timestamp = date.getTime() / 1000;
-				setTagValue(t, timestamp);
+				//some easy checks to determine two common date formats
+				var timestamp = date.parseExifDate(dateStrVal);
+				if(typeof timestamp !== 'undefined') {
+					setTagValue(t, timestamp);
+				}
 			}
 		});
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exif-parser",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A javascript library to extract Exif metadata from images, in node and in the browser.",
   "author": "Bruno Windels <bruno.windels@gmail.com>",
   "keywords": [

--- a/test/test-date.js
+++ b/test/test-date.js
@@ -1,0 +1,25 @@
+var date = require('../lib/date');
+
+var minutes = 60;
+var hours = minutes * 60;
+var days = hours * 24;
+var years = days * 365;
+var leapYears = days * 366;
+
+module.exports = {
+	'test parse unix epoch without timezone': function(test) {
+		var dateStr = '1970:01:01 00:00:00';
+		var timestamp = date.parseDateWithSpecFormat(dateStr);
+		test.strictEqual(timestamp, 0);
+		test.done();
+	},
+	'test parse given date without timezone': function(test) {
+		var dateStr = '1990:02:14 14:30:14';
+		var timestamp = date.parseDateWithSpecFormat(dateStr);
+		//between 1970 and 1990 there were 5 leap years: 1972, 1976, 1980, 1984, 1988
+		var expectedTimestamp = (15 * years) + (5 * leapYears) +
+			((31 + 13) * days) + (14 * hours) + (30 * minutes) + 14;
+		test.strictEqual(timestamp, expectedTimestamp);
+		test.done();
+	}
+}

--- a/test/test-date.js
+++ b/test/test-date.js
@@ -21,5 +21,35 @@ module.exports = {
 			((31 + 13) * days) + (14 * hours) + (30 * minutes) + 14;
 		test.strictEqual(timestamp, expectedTimestamp);
 		test.done();
+	},
+	'test parse invalid date without timezone should not return anything': function(test) {
+		var dateStr = '1990:AA:14 14:30:14';
+		var timestamp = date.parseDateWithSpecFormat(dateStr);
+		test.strictEqual(timestamp, undefined);
+		test.done();
+	},
+	'test parse given date with timezone': function(test) {
+		var dateStr = '2004-09-04T23:39:06-08:00';
+		var timestamp = date.parseDateWithTimezoneFormat(dateStr);
+		var yearsFromEpoch = 2004 - 1970;
+		//1972, 1976, 1980, 1984, 1988, 1992, 1996, 2000
+		var leapYearsCount = 8;
+		//2004 is a leap year as well, hence 29 days for february
+		var dayCount = 31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 3;
+		var expectedTimestamp = (yearsFromEpoch - leapYearsCount) * years +
+			leapYearsCount * leapYears +
+			dayCount * days +
+			23 * hours +
+			39 * minutes +
+			6 +
+			8 * hours;	//for timezone
+		test.strictEqual(timestamp, expectedTimestamp);
+		test.done();
+	},
+	'test parse invalid date with timezone': function(test) {
+		var dateStr = '2004-09-04T23:39:06A08:00';
+		var timestamp = date.parseDateWithTimezoneFormat(dateStr);
+		test.strictEqual(timestamp, undefined);
+		test.done();
 	}
 }

--- a/test/test-date.js
+++ b/test/test-date.js
@@ -51,5 +51,10 @@ module.exports = {
 		var timestamp = date.parseDateWithTimezoneFormat(dateStr);
 		test.strictEqual(timestamp, undefined);
 		test.done();
+	},
+	'test parseExifDate': function(test) {
+		test.strictEqual(date.parseExifDate('1970:01:01 00:00:00'), 0);
+		test.strictEqual(date.parseExifDate('1970-01-01T00:00:00-01:00'), 3600);
+		test.done();
 	}
 }

--- a/test/test-simplify.js
+++ b/test/test-simplify.js
@@ -1,0 +1,22 @@
+var simplify = require('../lib/simplify');
+
+module.exports = {
+	'test castDateValues': function(test) {
+		var values = {
+			'DateTimeOriginal': '1970:01:01 00:00:00',
+			'CreateDate': '1970-01-01T00:00:00-05:00'
+		};
+		var setValues = {};
+		function getTagValue(tag) {
+			return values[tag.name];
+		}
+		function setTagValue(tag, value) {
+			setValues[tag.name] = value;
+		}
+		simplify.castDateValues(getTagValue, setTagValue);
+		test.strictEqual(Object.keys(setValues).length, 2);
+		test.strictEqual(setValues.DateTimeOriginal, 0);
+		test.strictEqual(setValues.CreateDate, 5 * 3600);
+		test.done();
+	}
+}


### PR DESCRIPTION
Fixes same issue as https://github.com/bwindels/exif-parser/pull/5, but code is refactored to not use regular expressions and includes unit tests. 