### PR TITLE
Ignoring unknown tag format

### DIFF
--- a/lib/exif.js
+++ b/lib/exif.js
@@ -35,7 +35,7 @@ function getBytesPerComponent(format) {
 		case 12:
 			return 8;
 		default:
-			throw new Error('Invalid format: ' + format);
+			return 0;
 	}
 }
 
@@ -67,7 +67,7 @@ function readExifTag(tiffMarker, stream) {
 	else if(format === 7) {
 		values = stream.nextBuffer(components);
 	}
-	else {
+	else if(format !== 0) {
 		values = [];
 		for(c = 0; c < components; ++c) {
 			values.push(readExifValue(format, stream));


### PR DESCRIPTION
@bwindels Some photos have invalid exif tag types (e.g. 0), which causes `getBytesPerComponent()` to throw an error. Rather than throw an error, I need the library to simply ignore the value so that execution can continue and we can still used the correctly parsed exif data.
