### PR TITLE
fix(date.js): set month & date at the same time

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -13,8 +13,7 @@ function parseDateTimeParts(dateParts, timeParts) {
 	timeParts = timeParts.map(parseNumber);
 	var date = new Date();
 	date.setUTCFullYear(dateParts[0]);
-	date.setUTCMonth(dateParts[1] - 1);
-	date.setUTCDate(dateParts[2]);
+	date.setUTCMonth(dateParts[1] - 1, dateParts[2]);
 	date.setUTCHours(timeParts[0]);
 	date.setUTCMinutes(timeParts[1]);
 	date.setUTCSeconds(timeParts[2]);


### PR DESCRIPTION
This fixes a bug where on certain dates the parsed exif date will be one month after it should be.

Quick explanation: A new date object has the current date (i.e. 31st of May), if you now set the month to a month that has no 31st it will automatically choose the next month that has a 31st… Fix is to pass the day as the second parameter to `setUTCMonth`.

Otherwise everything works great, seems to be the best exif-parser out there! Thanks for your work!
