### PR TITLE
Fixed global.

### DIFF
--- a/browser-global.js
+++ b/browser-global.js
@@ -1,3 +1,3 @@
 var api = require('./index');
-var global = (function () { return this; }());
+var global = (1,eval)('this');
 global.ExifParser = api;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var Parser = require('./lib/parser');
 
 function getGlobal() {
-	return this;
+	return (1,eval)('this');
 }
 
 module.exports = {


### PR DESCRIPTION
Getting the global object fails if this code is used in the browser through something like Browserify.

This code is guaranteed in all modern environment to return the global object.

See [indirect `eval` call](http://kangax.github.io/jstests/indirect_eval_call_test/) for info.

Thanks for a great library. This library is now utilized on [mino.dk/dansksiden](https://mino.dk/dansksiden) (sorry, it's in danish) - which uses Browserify.
