### PR TITLE
Duplicate exif values (specifically for Orientation)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -170,7 +170,9 @@ Parser.prototype = {
 						if(!name) {
 							name = tagNames.exif[tagType];
 						}
-						tags[name] = value;
+						if (!tags[name]) {
+							tags[name] = value;
+						}
 					} else {
 						tags.push({
 							section: ifdSection,


### PR DESCRIPTION
Some images, it seems from some older iphones, may contain duplicate exif tags for Orientation, which result in incorrectly rotated images.

The fix seems to be to use the first exif tag found, instead of the last one found.

For example, exiftool shows the correct orientation (1) however, exif-parser shows Orientation 6 for this image:

https://s3.amazonaws.com/dev-sgs-source-images/WNYREIS/B/4/B471754/orig-2-12_Plum_Creek-Ellicottville-NY-14731.jpeg