### PR TITLE
Fixes incorrect dates from parsed values

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ exif-parser
 ========
 exif-parser is a parser for image metadata in the exif format, the most popular metadata format for jpeg and tiff images. It is written in pure javascript and has no external dependencies. It can also get the size of jpeg images and the size of the jpeg thumbnail embedded in the exif data. It can also extract the embedded thumbnail image.
 
-###Installing
+### Installing
 
     npm install exif-parser
 
@@ -18,7 +18,7 @@ This will generate a `dist/exif-parser-(version).js` and `dist/exif-parser-(vers
 
 	var parser = window.ExifParser.create(arrayBuffer);
 
-###Creating a parser
+### Creating a parser
 To start parsing exif data, create a new parser like below. Note that the buffer you pass does not have to be the buffer for the full jpeg file. The exif section of a jpeg file has a maximum size of 65535 bytes and the section seems to always occur within the first 100 bytes of the file. So it is safe to only fetch the first 65635 bytes of a jpeg file and pass those to the parser.
 
 The buffer you pass to create can be a node buffer or a DOM ArrayBuffer.
@@ -28,7 +28,7 @@ var parser = require('exif-parser').create(buffer);
 var result = parser.parse();
 ```
 
-###Setting the flags
+### Setting the flags
 
 Before calling parse, you can set a number of flags on the parser, telling it how to behave while parsing.
 
@@ -57,12 +57,12 @@ Enabling this tries to cast values as much as possible to the appropriate javasc
 
     parser.enableSimpleValues([boolean]), default true;
 
-###working with the result
+### working with the result
 
-####Getting the tags
+#### Getting the tags
 the tags that were found while parsing are stored in ```result.tags``` unless you set ```parser.enableReturnTags(false)```. If ```parser.enableTagNames``` is set to true, ```result.tags``` will be an object with the key being the tag name and the value being the tag value. If ```parser.enableTagNames``` is set to false, ```result.tags``` will be an array of objects containing section, type and value properties.
 
-####Getting the image size
+#### Getting the image size
 If ```parser.enableImageSize``` is set to true, ```result.getImageSize()``` will give you the image size as an object with width and height properties.
 
 ####Getting the thumbnail

--- a/lib/date.js
+++ b/lib/date.js
@@ -11,15 +11,14 @@ var minutes = 60;
 function parseDateTimeParts(dateParts, timeParts) {
 	dateParts = dateParts.map(parseNumber);
 	timeParts = timeParts.map(parseNumber);
-	var date = new Date();
-	date.setUTCFullYear(dateParts[0]);
-	date.setUTCMonth(dateParts[1] - 1);
-	date.setUTCDate(dateParts[2]);
-	date.setUTCHours(timeParts[0]);
-	date.setUTCMinutes(timeParts[1]);
-	date.setUTCSeconds(timeParts[2]);
-	date.setUTCMilliseconds(0);
-	var timestamp = date.getTime() / 1000;
+	var year = dateParts[0];
+	var month = dateParts[1] - 1;
+	var day = dateParts[2];
+	var hours = timeParts[0];
+	var minutes = timeParts[1];
+	var seconds = timeParts[2];
+	var date = Date.UTC(year, month, day, hours, minutes, seconds, 0);
+	var timestamp = date / 1000;
 	return timestamp;
 }
 
@@ -32,7 +31,7 @@ function parseDateWithTimezoneFormat(dateTimeStr) {
 	var timeParts = dateTimeStr.substr(11, 8).split(':');
 	var timezoneStr = dateTimeStr.substr(19, 6);
 	var timezoneParts = timezoneStr.split(':').map(parseNumber);
-	var timezoneOffset = (timezoneParts[0] * hours) + 
+	var timezoneOffset = (timezoneParts[0] * hours) +
 		(timezoneParts[1] * minutes);
 
 	var timestamp = parseDateTimeParts(dateParts, timeParts);
@@ -50,7 +49,7 @@ function parseDateWithSpecFormat(dateTimeStr) {
 	var parts = dateTimeStr.split(' '),
 		dateParts = parts[0].split(':'),
 		timeParts = parts[1].split(':');
-	
+
 	var timestamp = parseDateTimeParts(dateParts, timeParts);
 
 	if(typeof timestamp === 'number' && !isNaN(timestamp)) {


### PR DESCRIPTION
Closes #23 

Using `new date()` returns the current system date. Modifying the date afterwards can have unexpected consequences if the system's date is the 31st. For instance, parsing 2015-09-12
``` 
var date = new Date()  # date is set to system date (2017-05-31, for instance) 
date.setUTCFullYear(dateParts[0]); # date is now 2015-05-31 
date.setUTCMonth(dateParts[1] - 1); # date is now 2015-10-01, because 2015-09-31 is not a valid date
date.setUTCDate(dateParts[2]); # date is now 2015-10-12
```
The resulting date is one month ahead of what was parsed.

Writing a regression test is difficult as it would necessitate setting the system date.
