### PR TITLE
Fixes 'Offset is outside the bounds of the DataView' error

### DIFF
--- a/lib/exif.js
+++ b/lib/exif.js
@@ -83,6 +83,10 @@ function readExifTag(tiffMarker, stream) {
 }
 
 function readIFDSection(tiffMarker, stream, iterator) {
+	// make sure we can read nextUint16 byte
+	if (stream.remainingLength() < 2){
+		return;
+	}
 	var numberOfEntries = stream.nextUInt16(), tag, i;
 	for(i = 0; i < numberOfEntries; ++i) {
 		tag = readExifTag(tiffMarker, stream);


### PR DESCRIPTION
Some images cause exif parser to fail when reading nextUint16.
To reproduce, simply upload an image to polarr (https://photoeditor.polarr.co/), manipulate it a bit, download it and try to parse exif data.

Example image:
![polarred](https://user-images.githubusercontent.com/17675159/35194796-8f976e28-feb9-11e7-9b97-623854654bdf.jpg)
