### PR TITLE
Add a 'license' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "tiff",
     "gps"
   ],
+  "license": "MIT",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This avoids a warning from npm, and makes this package license information consumable by tools.